### PR TITLE
script + style end tag parse case insensitive

### DIFF
--- a/src/trane.erl
+++ b/src/trane.erl
@@ -167,10 +167,10 @@ tz(X,"")                                  -> {X,"",eof}.
 
 ff(What,Str) -> ff(What,Str,0,Str).
 
-ff(script,<<"</script>",Str/binary>>,N,Bin) ->
+ff(script,<<Tag:9/binary,Str/binary>>,N,Bin) when Tag=:=<<"</script>">>;Tag=:=<<"</SCRIPT>">> ->
   {Scr,_} = split_binary(Bin,N),
   {{tag,""},<<"/script>",Str/binary>>,{text,Scr}};
-ff(style,<<"</style>",Str/binary>>,N,Bin) ->
+ff(style,<<Tag:8/binary,Str/binary>>,N,Bin) when Tag=:=<<"</style>">>;Tag=:=<<"</STYLE>">> ->
   {Scr,_} = split_binary(Bin,N),
   {{tag,""},<<"/style>",Str/binary>>,{text,Scr}};
 ff(text,<<"<",Str/binary>>,N,Bin) ->


### PR DESCRIPTION
I was running into issues for html like the following:
```
<html>
<body>
<div>
  <div>
    <div>
      <div>
        <STYLE>
          body{background-color: red;}
        </STYLE>
      </div>
      <div>
      </div>
    </div>
  </div>
</div>
<div>
output
</div>
</body>
</html>
```

whenever the style tag was capitalized, we were only matching on lowercase `</style>`, so it'd parse through everything else without emitting the text inside of the style tag. also added some logic in the case `script` tags are capitalized. 